### PR TITLE
Temporarily disable SonarQube

### DIFF
--- a/.github/workflows/java-continuous-integration.yml
+++ b/.github/workflows/java-continuous-integration.yml
@@ -63,6 +63,7 @@ jobs:
           cache: 'maven'
 
       - name: cache SonarQube packages
+        if: false # temporarily disabled - SonarQube server returning 503
         uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
@@ -117,6 +118,7 @@ jobs:
           GITHUB_ACCESS_TOKEN: ${{ secrets.MAIN_GITHUB_RELEASE_TOKEN }}
 
       - name: set up JDK 21 for Sonar Scan
+        if: false # temporarily disabled - SonarQube server returning 503
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -125,6 +127,7 @@ jobs:
           cache: 'maven'
 
       - name: SonarQube scan
+        if: false # temporarily disabled - SonarQube server returning 503
         run: |
           mvn --batch-mode --no-transfer-progress \
             sonar:sonar \


### PR DESCRIPTION
Wegen: 
`Error:  Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar (default-cli) on project ozdserver: Unable to execute SonarScanner analysis: Fail to get bootstrap index from server: Status returned by url [***batch/index] is not valid: [503] -> [Help 1]`